### PR TITLE
fix: save objects only after clearing the index

### DIFF
--- a/module.js
+++ b/module.js
@@ -35,7 +35,7 @@ export default function algoliaModule(moduleOptions = {}) {
             const index = client.initIndex(indexName)
     
             // clear the index in case any documents were removed
-            index.clearObjects()
+            await index.clearObjects()
             
             const { objectIDs } = await index.saveObjects(docs)
             consola.success(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-content-algolia",
-  "version": "0.2.0",
+  "version": "0.3.1",
   "description": "Sync content stored in markdown files in your Nuxt project to algolia ",
   "main": "module.js",
   "scripts": {


### PR DESCRIPTION
Without this fix, the clearObjects call can intermittently fire *after* the saveObjects call because we don't wait for the promise to resolve before saving.

This sometimes results in no records in the algolia index.

**Before**

These are the API logs from Algolia, with the most recent at the top. Notice in several of these, the `clear` happens after the `batch` call.
<img width="1471" alt="Screen Shot 2022-01-04 at 11 47 21 PM" src="https://user-images.githubusercontent.com/1950226/148179940-c19fe6b6-0ce9-4e46-a16d-d7b583d04849.png">
.

**After**
`batch` is now consistently happening after `clear`.
<img width="1476" alt="Screen Shot 2022-01-04 at 11 42 32 PM" src="https://user-images.githubusercontent.com/1950226/148180157-5dfd1093-601f-4e6c-9fbd-237067f49dbf.png">

